### PR TITLE
Add RBAC rules for CSI csidrivers CRD

### DIFF
--- a/deploy/kubernetes/rbac.yaml
+++ b/deploy/kubernetes/rbac.yaml
@@ -19,21 +19,11 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: driver-registrar-runner
+  name: cluster-driver-registrar-role
 rules:
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
-  # The following permissions are only needed when running
-  # driver-registrar without the --kubelet-registration-path
-  # parameter, i.e. when using driver-registrar instead of
-  # kubelet to update the csi.volume.kubernetes.io/nodeid
-  # annotation. That mode of operation is going to be deprecated
-  # and should not be used anymore, but is needed on older
-  # Kubernetes versions.
-  # - apiGroups: [""]
-  #   resources: ["nodes"]
-  #   verbs: ["get", "update", "patch"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csidrivers"]
+    verbs: ["create", "delete"]
 
 ---
 kind: ClusterRoleBinding
@@ -47,5 +37,5 @@ subjects:
     namespace: default
 roleRef:
   kind: ClusterRole
-  name: driver-registrar-runner
+  name: cluster-driver-registrar-role
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Add the RBAC rules for csidrivers crd which was missing from rbac.yaml

Tested without the rules and get errors in creating csidrivers CRD objects. 

E0109 18:08:45.418972       1 k8s_register.go:118] Failed to create CSIDriver object: csidrivers.csi.storage.k8s.io is forbidden: User "system:serviceaccount:mapr-csi:csi-provisioner-sa" cannot create resource "csidrivers" in API group "csi.storage.k8s.io" at the cluster scope

With fix, Able to get the correct CRD object being created for csidrivers.