### PR TITLE
k8s_register.go: graceful termination

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,30 @@ features:
   namespace to the NodePublish call
 
 If you are not using one of these features, this sidecar container (and the
-creation of the CSIDriver Object) is not required. However, it is still
+creation of the CSIDriver object) is not required. However, it is still
 recommended, because the CSIDriver Object makes it easier for users to easily
-discover the CSI drivers installed on their clusters.
+discover the CSI drivers installed on their clusters:
+
+``` bash
+$ kubectl describe csidrivers.storage.k8s.io
+Name:         io.kubernetes.storage.mock
+Namespace:    
+Labels:       <none>
+Annotations:  <none>
+API Version:  storage.k8s.io/v1beta1
+Kind:         CSIDriver
+Metadata:
+  Creation Timestamp:  2019-03-15T08:48:28Z
+  Resource Version:    524
+  Self Link:           /apis/storage.k8s.io/v1beta1/csidrivers/io.kubernetes.storage.mock
+  UID:                 1a4f5f40-46ff-11e9-bfc7-fcaa1497a416
+Spec:
+  Attach Required:    true
+  Pod Info On Mount:  false
+Events:               <none>
+```
+
+
 
 ## Compatibility
 
@@ -52,7 +73,6 @@ objects. A sample RBAC configuration can be found at
 ### Example
 
 Here is an example sidecar spec in the driver's controller StatefulSet.
-`<drivername.example.com>` should be replaced by the actual driver's name.
 
 ```bash
       containers:
@@ -68,6 +88,16 @@ Here is an example sidecar spec in the driver's controller StatefulSet.
         - name: plugin-dir
           emptyDir: {}
 ```
+
+### Deinstalling a driver
+
+The cluster-driver-registrar will remove the CSIDriver object when it
+terminates. For this to work, the RBAC rules that grant the sidecar
+the necessary permissions must still be installed. A reliable way to
+achieve this when using a StatefulSet is:
+- scale down a StatefulSet to zero replicas (because of
+  https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#limitations)
+- remove the StatefulSet and RBAC rules
 
 ## Community, discussion, contribution, and support
 

--- a/cmd/csi-cluster-driver-registrar/k8s_register.go
+++ b/cmd/csi-cluster-driver-registrar/k8s_register.go
@@ -19,6 +19,7 @@ package main
 import (
 	"os"
 	"os/signal"
+	"syscall"
 	"time"
 
 	k8scsi "k8s.io/api/storage/v1beta1"
@@ -42,8 +43,9 @@ func kubernetesRegister(
 	}
 
 	// Set up goroutine to cleanup (aka deregister) on termination.
+	// Kubernetes uses SIGTERM, not SIGINT.
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
+	signal.Notify(c, syscall.SIGTERM)
 	go cleanup(c, clientset, csiDriver)
 
 	// Run forever

--- a/cmd/csi-cluster-driver-registrar/k8s_register.go
+++ b/cmd/csi-cluster-driver-registrar/k8s_register.go
@@ -74,7 +74,7 @@ func verifyAndAddCSIDriverInfo(
 			klog.V(1).Infof("CSIDriver object created for driver %s", csiDriver.Name)
 			return nil
 		} else if apierrors.IsAlreadyExists(err) {
-			klog.V(1).Info("CSIDriver CRD already had been registered")
+			klog.V(1).Info("CSIDriver object already had been registered")
 			return nil
 		}
 		klog.Errorf("Failed to create CSIDriver object: %v", err)

--- a/cmd/csi-cluster-driver-registrar/main.go
+++ b/cmd/csi-cluster-driver-registrar/main.go
@@ -48,10 +48,10 @@ const (
 var (
 	kubeconfig        = flag.String("kubeconfig", "", "Absolute path to the kubeconfig file. Required only when running out of cluster.")
 	k8sPodInfoOnMount = flag.Bool("pod-info-mount", false,
-		"This indicates that the associated CSI volume driver"+
-			"requires additional pod information (like podName, podUID, etc.) during mount."+
-			"When set to true, Kubelet will send the followings pod information "+
-			"during NodePublishVolume() calls to the driver as VolumeAttributes:"+
+		"This indicates that the associated CSI volume driver\n"+
+			"requires additional pod information (like podName, podUID, etc.) during mount.\n"+
+			"When set to true, Kubelet will send the followings pod information\n"+
+			"during NodePublishVolume() calls to the driver as VolumeAttributes:\n"+
 			"- csi.storage.k8s.io/pod.name: pod.Name\n"+
 			"- csi.storage.k8s.io/pod.namespace: pod.Namespace\n"+
 			"- csi.storage.k8s.io/pod.uid: string(pod.UID)",


### PR DESCRIPTION
Kubernetes sends SIGTERM, not SIGINT, when it asks processes to
terminate.

Fixes: #40